### PR TITLE
Use TARGET_OS_IPHONE macro

### DIFF
--- a/Headers/Public/VLCMediaPlayer.h
+++ b/Headers/Public/VLCMediaPlayer.h
@@ -809,7 +809,7 @@ extern NSString *const VLCTitleDescriptionIsMenu;
  */
 @property (NS_NONATOMIC_IOSONLY, readonly, copy) NSArray *snapshots;
 
-#if TARGET_OS_PHONE
+#if TARGET_OS_IPHONE
 /**
  * Get last snapshot available.
  * \return an UIImage with the last snapshot available.


### PR DESCRIPTION
In `VLCMediaPlayer`, `NSImage` is undefined with *phones therefore breaking the build.
This PR fixes the macro!