### PR TITLE
VLCMediaPlayer: Don't release equalizer on disable

### DIFF
--- a/Headers/Public/VLCMediaPlayer.h
+++ b/Headers/Public/VLCMediaPlayer.h
@@ -607,6 +607,7 @@ extern NSString *const VLCTitleDescriptionIsMenu;
 /**
  * Toggle equalizer state
  * param: bool value to enable/disable the equalizer
+ * \note this can fail, if failed the value will not be changed
  * \return current state */
 @property (readwrite) BOOL equalizerEnabled;
 

--- a/Sources/VLCMediaPlayer.m
+++ b/Sources/VLCMediaPlayer.m
@@ -974,17 +974,11 @@ static void HandleMediaPlayerSnapshot(const libvlc_event_t * event, void * self)
 - (void)setEqualizerEnabled:(BOOL)equalizerEnabled
 {
     _equalizerEnabled = equalizerEnabled;
-    if (!_equalizerEnabled) {
-        libvlc_media_player_set_equalizer(_playerInstance, NULL);
-
-        if (_equalizerInstance)
-            libvlc_audio_equalizer_release(_equalizerInstance);
-        return;
-    }
-
-    if (!_equalizerInstance)
+    if (!_equalizerInstance) {
         _equalizerInstance = libvlc_audio_equalizer_new();
-    libvlc_media_player_set_equalizer(_playerInstance, _equalizerInstance);
+    }
+    libvlc_media_player_set_equalizer(_playerInstance,
+                                      equalizerEnabled ? _equalizerInstance : NULL);
 }
 
 - (BOOL)equalizerEnabled

--- a/Sources/VLCMediaPlayer.m
+++ b/Sources/VLCMediaPlayer.m
@@ -973,10 +973,14 @@ static void HandleMediaPlayerSnapshot(const libvlc_event_t * event, void * self)
 
 - (void)setEqualizerEnabled:(BOOL)equalizerEnabled
 {
-    _equalizerEnabled = equalizerEnabled;
     if (!_equalizerInstance) {
-        _equalizerInstance = libvlc_audio_equalizer_new();
+        if (!(_equalizerInstance = libvlc_audio_equalizer_new())) {
+            NSAssert(_instance, @"equalizer failed to initialize");
+            return;
+        }
     }
+
+    _equalizerEnabled = equalizerEnabled;
     libvlc_media_player_set_equalizer(_playerInstance,
                                       equalizerEnabled ? _equalizerInstance : NULL);
 }


### PR DESCRIPTION
Remove the release of the equalizer instance when disabling it.
Releasing it every time could lead to some information loss.

`_equalizerInstance` is released on `dealloc`.