### PR TITLE
build: Change modules for Chromecast

### DIFF
--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -323,7 +323,7 @@ buildLibVLC() {
     export USE_FFMPEG=1
     ../bootstrap ${BUILD} --host=${TARGET} --prefix=${VLCROOT}/contrib/${OSSTYLE}-${TARGET}-${ARCH} --disable-gpl \
         --enable-ad-clauses \
-        --disable-disc --disable-sout \
+        --disable-disc \
         --disable-sdl \
         --disable-SDL_image \
         --disable-iconv \
@@ -356,7 +356,6 @@ buildLibVLC() {
         --disable-gnutls \
         --disable-lua \
         --disable-luac \
-        --disable-protobuf \
         --disable-aribb24 \
         --disable-aribb25 \
         --enable-vpx \
@@ -547,10 +546,8 @@ buildLibVLC() {
     demuxdump
     fingerprinter
     output_udp
-    output_http
     output_livehttp
     libmux
-    stream_out
     "
 
     if [ "$SCARY" = "no" ]; then


### PR DESCRIPTION
This patch removes some modules from the blacklist and enables modules needed for Chromecast.