### PR TITLE
Add singular form for verbose time description

### DIFF
--- a/Headers/Public/VLCTime.h
+++ b/Headers/Public/VLCTime.h
@@ -79,7 +79,7 @@
  */
 @property (readonly) NSString * stringValue;
 /**
- * the current time value as verbose string value localized for the current environment
+ * the current time value as verbose localized string by spelling out the units of time, but not the quantities
  * \return the NSString object
  */
 @property (readonly) NSString * verboseStringValue;

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ Version 3.1.0:
 - Expose yaw, pitch, roll and fov for viewpoint
 - Include protobuf, sout, output_http and stream_out modules for Chromecast
 - Rename buildMobileVLCKit to compileAndBuildVLCKit
+- VLCTime.verboseStringValue now returns a localized string by spelling out the units of time, but not the quantities. Given the quantity of 1 hour, 30 minutes, and 17 seconds, the function returns the string "1 hour 30 minutes 17 seconds" in the U.S. English locale
 
 Version 3.0.2:
 --------------

--- a/Sources/VLCTime.m
+++ b/Sources/VLCTime.m
@@ -114,21 +114,15 @@
     long mins = (long)((positiveDuration / 60) % 60);
     long seconds = (long)(positiveDuration % 60);
     BOOL remaining = duration < 0;
-    NSString *format;
-    if (hours > 0) {
-        format = remaining ? NSLocalizedString(@"%ld hours %ld minutes remaining", nil) : NSLocalizedString(@"%ld hours %ld minutes", nil);
-        return [NSString stringWithFormat:format, hours, mins, remaining];
-    }
-    if (mins > 5) {
-        format = remaining ? NSLocalizedString(@"%ld minutes remaining", nil) : NSLocalizedString(@"%ld minutes", nil);
-        return [NSString stringWithFormat:format, mins, remaining];
-    }
-    if (mins > 0) {
-        format = remaining ? NSLocalizedString(@"%ld minutes %ld seconds remaining", nil) : NSLocalizedString(@"%ld minutes %ld seconds", nil);
-        return [NSString stringWithFormat:format, mins, seconds, remaining];
-    }
-    format = remaining ? NSLocalizedString(@"%ld seconds remaining", nil) : NSLocalizedString(@"%ld seconds", nil);
-    return [NSString stringWithFormat:format, seconds, remaining];
+   
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    [components setHour:hours];
+    [components setMinute:mins];
+    [components setSecond:seconds];
+
+    NSString *verboseString = [NSDateComponentsFormatter localizedStringFromDateComponents:components unitsStyle:NSDateComponentsFormatterUnitsStyleFull];
+    verboseString = remaining ? [NSString stringWithFormat:@"%@ remaining", verboseString] : verboseString;
+    return [verboseString stringByReplacingOccurrencesOfString:@"," withString:@""];
 }
 
 - (NSString *)minuteStringValue


### PR DESCRIPTION
When using `VLCTime.verboseDescription`,

1 **minutes** 20 seconds is now 1 **minute** 20 seconds