### PR TITLE
Fix documentation warnings

### DIFF
--- a/Headers/Public/VLCMediaPlayer.h
+++ b/Headers/Public/VLCMediaPlayer.h
@@ -260,7 +260,7 @@ extern NSString * VLCMediaPlayerStateToString(VLCMediaPlayerState state);
  * Enable or disable deinterlace and specify which filter to use
  *
  *
- * \param VLCDeinterlace - enable, disable or auto
+ * \param deinterlace - enable, disable or auto
  * \param name of deinterlace filter to use (availability depends on underlying VLC version).
  */
 - (void)setDeinterlace:(VLCDeinterlace)deinterlace withFilter:(NSString *)name;
@@ -774,10 +774,10 @@ extern NSString *const VLCTitleDescriptionIsMenu;
 
 /**
  * Updates viewpoint with given values.
- * \param view point yaw in degrees  ]-180;180]
- * \param view point pitch in degrees  ]-90;90]
- * \param view point roll in degrees ]-180;180]
- * \param field of view in degrees ]0;180[ (default 80.)
+ * \param yaw view point yaw in degrees  ]-180;180]
+ * \param pitch view point pitch in degrees  ]-90;90]
+ * \param roll view point roll in degrees ]-180;180]
+ * \param fov field of view in degrees ]0;180[ (default 80.)
  * \param absolute if true replace the old viewpoint with the new one. If
  * false, increase/decrease it.
  * \return NO in case of error, YES otherwise


### PR DESCRIPTION
* Added missing parameter declaration to fix warnings

Current vlckit related warnings:

<img width="783" alt="screen shot 2018-05-21 at 20 22 01" src="https://user-images.githubusercontent.com/11726424/40323086-abc9ee70-5d34-11e8-8aee-b7ac5019e000.png">
