### PR TITLE
Setup CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+
+jobs:
+  build:
+    macos:
+      xcode: "9.3.0"
+    environment:
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: libvlc-{{ checksum "compileAndBuildVLCKit.sh" }}
+      - run:
+          name: Build VLCKit
+          command: |
+            rake build:vlckit:ios
+      - save_cache:
+          key: libvlc-{{ checksum "compileAndBuildVLCKit.sh" }}
+          paths:
+            - build
+            - libvlc
+            - Resources
+      - run:
+          name: Run Tests
+          command: |
+            rake test:ios
+


### PR DESCRIPTION
I've tested the following config file on my personal trial CircleCI account and so far, it looks promising!

Basically, I am saving the folders generated from `./compileAndBuildVLCKit.sh` as cache so VLCKit doesn't have to re-built every single time.

Here are some interesting performance stats.

- Running `./compileAndBuildVLCKit.sh` from scratch: **32 minutes**
- Restoring VLCKit from cache and skipping above step: **1 minute 58 seconds**

Please note that the whole thing is configured for iOS. More changes should be made to make it compatible with tvOS/macOS in the future 😄 