### PR TITLE
buildscript: Fix tvOS build

### DIFF
--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -1101,12 +1101,12 @@ if [ "$TVOS" = "yes" ]; then
 
     lipo_libs=""
     platform=""
-    if [ -d ${VLCROOT}/install-AppleTVOS ];then
+    if [ "$FARCH" = "all" ] || (! is_simulator_arch $FARCH);then
         platform="appletvos"
         buildxcodeproj MobileVLCKit "TVVLCKit" ${platform}
         lipo_libs="$lipo_libs ${CONFIGURATION}-appletvos/libTVVLCKit.a"
     fi
-    if [ -d ${VLCROOT}/install-AppleTVSimulator ];then
+    if [ "$FARCH" = "all" ] || (is_simulator_arch $arch);then
         platform="appletvsimulator"
         buildxcodeproj MobileVLCKit "TVVLCKit" ${platform}
         lipo_libs="$lipo_libs ${CONFIGURATION}-appletvsimulator/libTVVLCKit.a"


### PR DESCRIPTION
For example, if we choose the compile only aarch64(with -a), it would go into the simulator part and fail since arm64 is not a simulator platform.