### PR TITLE
build: Fix simulators build (closes #178)

### DIFF
--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -755,7 +755,10 @@ build_universal_static_lib() {
     arch="aarch64"
     if [ "$FARCH" != "all" ];then
         arch="$FARCH"
+    elif [ "$BUILD_SIMULATOR" = "yes" ]; then
+        arch="x86_64"
     fi
+
     actual_arch=`get_actual_arch $arch`
 
     if [ -d ${VLCROOT}/install-"$OSSTYLE"OS ];then

--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -800,38 +800,37 @@ build_universal_static_lib() {
 
     if [ -d ${VLCROOT}/install-"$OSSTYLE"Simulator ];then
         spushd ${VLCROOT}/install-"$OSSTYLE"Simulator
-
-        if (is_simulator_arch $arch);then
-            echo "SIMU OS: $arch"
-            spushd $actual_arch/lib/vlc/plugins
-            for i in `ls *.a`
+            for i in `ls .`
             do
-                VLCMODULES="$i $VLCMODULES"
+                local iarch="`get_arch $i`"
+                if [ "$FARCH" == "all" -o "$FARCH" = "$iarch" ];then
+                    SIMULATORARCHS="$SIMULATORARCHS $iarch"
+                fi
             done
-            spopd # $actual_arch/lib/vlc/plugins
-        fi
-        for i in `ls .`
-        do
-            local iarch="`get_arch $i`"
-            if [ "$FARCH" == "all" -o "$FARCH" = "$iarch" ];then
-                SIMULATORARCHS="$SIMULATORARCHS $iarch"
+
+            if (is_simulator_arch $arch);then
+                echo "SIMU OS: $arch"
+                spushd $arch/lib/vlc/plugins
+                    for i in `ls *.a`
+                    do
+                        VLCMODULES="$i $VLCMODULES"
+                    done
+                spopd # $iarch/lib/vlc/plugins
             fi
-        done
         spopd # vlc-install-"$OSSTYLE"Simulator
     fi
 
     if [ "$OSSTYLE" = "MacOSX" ]; then
         if [ -d ${VLCROOT}/install-"$OSSTYLE" ];then
             spushd ${VLCROOT}/install-"$OSSTYLE"
-            echo `pwd`
-            echo "macOS: $arch"
-            spushd $arch/lib/vlc/plugins
-            for i in `ls *.a`
-            do
-                VLCMODULES="$i $VLCMODULES"
-            done
-            spopd # $actual_arch/lib/vlc/plugins
-
+                echo `pwd`
+                echo "macOS: $arch"
+                spushd $arch/lib/vlc/plugins
+                    for i in `ls *.a`
+                    do
+                        VLCMODULES="$i $VLCMODULES"
+                    done
+                spopd # $actual_arch/lib/vlc/plugins
             spopd # vlc-install-"$OSSTYLE"
         fi
     fi


### PR DESCRIPTION
In `build_universal_static_lib()` the architecture was set by default to arm64 which led to `No such file or directory` for simulators(`-s`).
