### PR TITLE
VLCLibrary: debugLogging status (closes #186)

### DIFF
--- a/Headers/Public/VLCLibrary.h
+++ b/Headers/Public/VLCLibrary.h
@@ -30,86 +30,79 @@
 @class VLCAudio;
 
 /**
- * The VLCLibrary is the base library of the VLCKit.framework.  This object provides a shared instance that exposes the
+ * The VLCLibrary is the base library of VLCKit.framework. This object provides a shared instance that exposes the
  * internal functionalities of libvlc and libvlc-control. The VLCLibrary object is instantiated automatically when
- * VLCKit.framework is loaded into memory.  Also, it is automatically destroyed when the VLCKit.framework is unloaded
+ * VLCKit.framework is loaded into memory.  Also, it is automatically destroyed when VLCKit.framework is unloaded
  * from memory.
  *
- * Currently, the framework does not support multiple instances of VLCLibrary.  Furthermore, you cannot destroy any
- * instiantiation of VLCLibrary, as previously noted, this is done automatically by the dynamic link loader.
+ * Currently, the framework does not support multiple instances of VLCLibrary.
+ * Furthermore, you cannot destroy any instance of VLCLibrary; this is done automatically by the dynamic link loader.
  */
 @interface VLCLibrary : NSObject
 
-/* Factories */
 /**
- * Returns the library's shared instance.
- * \return The library's shared instance.
+ * Returns the library's shared instance
+ * \return The library's shared instance
  */
 + (VLCLibrary *)sharedLibrary;
 
 /**
- * returns an individual instance which can be customized with options
- * \param options a NSArray with NSString instance containing the options
+ * Returns an individual instance which can be customized with options
+ * \param options NSArray with NSString instance containing the options
  * \return the individual library instance
  */
- - (instancetype)initWithOptions:(NSArray*)options;
+ - (instancetype)initWithOptions:(NSArray *)options;
 
 /**
- * enables/disables debug logging
- * param: debugLogging BOOL value to enable/disable
- * \note we will always log using NSLog
- * \return debug logging state
+ * Enables/disables debug logging
+ * \note NSLog is used to log messages
  */
 @property (readwrite, nonatomic) BOOL debugLogging;
 
 /**
- * gets/sets the debug logging level
- * param: debugLoggingLevel set level from 0 (all) to 4 (just error messages)
- * \return int debug level
-*/
+ * Gets/sets the debug logging level
+ * \note Logging level ranges from 0 (just error messages) to 4 (everything)
+ * \warning If an invalid level is provided, level defaults to 0
+ */
 @property (readwrite, nonatomic) int debugLoggingLevel;
 
 /**
  * Returns the library's version
- * \return The library version example "0.9.0-git Grishenko".
+ * \return The library version example "0.9.0-git Grishenko"
  */
-
 @property (readonly, copy) NSString *version;
 
 /**
  * Returns the compiler used to build the libvlc binary
  * \return The compiler version string.
  */
-
 @property (readonly, copy) NSString *compiler;
 
 /**
  * Returns the library's changeset
- * \return The library version example "adfee99".
+ * \return The library version example "adfee99"
  */
-
 @property (readonly, copy) NSString *changeset;
 
 /**
- * sets the application name and HTTP User Agend
+ * Sets the application name and HTTP User Agent
  * libvlc will pass it to servers when required by protocol
- * \param readableName human-readable application name, e.g. "FooBar player 1.2.3"
+ * \param readableName Human-readable application name, e.g. "FooBar player 1.2.3"
  * \param userAgent HTTP User Agent, e.g. "FooBar/1.2.3 Python/2.6.0"
  */
 - (void)setHumanReadableName:(NSString *)readableName withHTTPUserAgent:(NSString *)userAgent;
 
 /**
- * Sets some meta-information about the application.
- *
+ * Sets meta-information about the application
  * \param identifier Java-style application identifier, e.g. "com.acme.foobar"
- * \param version application version numbers, e.g. "1.2.3"
- * \param icon application icon name, e.g. "foobar"
+ * \param version Application version numbers, e.g. "1.2.3"
+ * \param icon Application icon name, e.g. "foobar"
  */
 - (void)setApplicationIdentifier:(NSString *)identifier withVersion:(NSString *)version andApplicationIconName:(NSString *)icon;
 
 /**
- * the libvlc instance wrapped by the VLCLibrary instance
- * \note if you want to use it, you are most likely wrong (or want to add a proper ObjC API)
+ * libvlc instance wrapped by the VLCLibrary instance
+ * \note If you want to use it, you are most likely wrong (or want to add a proper ObjC API)
  */
 @property (nonatomic, assign) void *instance;
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Version 3.1.3:
 --------------
 - Added missing VLCMediaParseStatusTimeout to VLCMediaParsedStatus enum
+- debugLoggingLevel of VLCLibrary defaults to 0 (just errors) when provided with invalid level
 
 Version 3.1.2:
 --------------

--- a/Sources/VLCLibrary.m
+++ b/Sources/VLCLibrary.m
@@ -71,7 +71,7 @@ static VLCLibrary * sharedLibrary = nil;
     return self;
 }
 
-- (instancetype)initWithOptions:(NSArray*)options
+- (instancetype)initWithOptions:(NSArray *)options
 {
     if (self = [super init]) {
         [self prepareInstanceWithOptions:options];
@@ -143,10 +143,24 @@ static VLCLibrary * sharedLibrary = nil;
     if (!_instance)
         return;
 
+    _debugLogging = debugLogging;
+    
     if (debugLogging) {
         libvlc_log_set(_instance, HandleMessage, (__bridge void *)(self));
     } else {
         libvlc_log_unset(_instance);
+    }
+}
+
+- (void)setDebugLoggingLevel:(int)debugLoggingLevel
+{
+    if (debugLoggingLevel >= 0 && debugLoggingLevel <= 4) {
+        _debugLoggingLevel = debugLoggingLevel;
+    } else {
+        VKLog(@"Invalid debugLoggingLevel of %d provided", debugLoggingLevel);
+        VKLog(@"Please provide a valid debugLoggingLevel between 0 and 4");
+        VKLog(@"Defaulting debugLoggingLevel to 0 (just errors)");
+        _debugLoggingLevel = 0;
     }
 }
 


### PR DESCRIPTION
Fixes the bugs

- `debugLoggingStatus` can not be set
- `debugLoggingLevel` can exceed the set range of 0-4