### PR TITLE
Added initializing VLCMedia from NSInputStream (using callbacks)

### DIFF
--- a/Headers/Public/VLCMedia.h
+++ b/Headers/Public/VLCMedia.h
@@ -161,6 +161,20 @@ typedef NS_ENUM(NSInteger, VLCMediaState) {
 - (instancetype)initWithPath:(NSString *)aPath;
 
 /**
+ * Initializes a new VLCMedia object to use an input stream.
+ *
+ * \note By default, NSStream instances that are not file-based are non-seekable,
+ * you may subclass NSInputStream whose instances are capable of seeking through a stream.
+ * This subclass must allow setting NSStreamFileCurrentOffsetKey property.
+ * \note VLCMedia will open stream if it is not already opened, and will close eventually.
+ * You can't pass an already closed input stream.
+ * \note VLCHTTPInputStream instance can be passed in order to stream remote media.
+ * \param stream Input stream for media to be accessed.
+ * \return A new VLCMedia object, only if there were no errors.
+ */
+- (instancetype)initWithStream:(NSInputStream *)stream;
+
+/**
  * TODO
  * \param aName TODO
  * \return A new VLCMedia object, only if there were no errors.


### PR DESCRIPTION
This PR adds `[VLCMedia initWithStream:]` initializer, also introduces `VLCHTTPInputStream` class to utilize `NSURLSession` for streaming http remote media.

`VLCHTTPInputStream` class can be used to deprecate VLCMedia initializing from http url as it uses `NSURLSession`, which can handle cellular data and multipath tcp. This class implements an internal cache in order to maintain smooth playing experience.

Later we can implement an stream using [sahlberg/libsmb2](https://github.com/sahlberg/libsmb2) to stream from smb2 servers and remove libdsm eventually.

[Discussion here](https://code.videolan.org/videolan/VLCKit/issues/162#note_15643).