### PR TITLE
Tests: VLCMediaList

### DIFF
--- a/MobileVLCKit.xcodeproj/project.pbxproj
+++ b/MobileVLCKit.xcodeproj/project.pbxproj
@@ -226,6 +226,8 @@
 		CABF4D4220D8DBA900FCCE29 /* VLCMediaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABF4D4020D8DBA900FCCE29 /* VLCMediaTest.swift */; };
 		CABCBAE220EB0B080040E2F5 /* VLCAudioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */; };
 		CABCBAE320EB0B080040E2F5 /* VLCAudioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */; };
+		CABEDACB210996D9005FED09 /* VLCMediaListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */; };
+		CABEDACC210996D9005FED09 /* VLCMediaListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */; };
 		CABF4D4520D8DCDD00FCCE29 /* libMobileVLCKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2AAC07E0554694100DB518D /* libMobileVLCKit.a */; };
 		CABF4D4620D8DD1B00FCCE29 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D797FC31DF41F9100AD93ED /* libc++.tbd */; };
 		CABF4D4720D8DD2000FCCE29 /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D24C2B51EC0A3390047E700 /* libbz2.tbd */; };
@@ -487,6 +489,7 @@
 		CABEDAB721095242005FED09 /* VLCLibraryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCLibraryTest.swift; sourceTree = "<group>"; };
 		CABF4D4020D8DBA900FCCE29 /* VLCMediaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCMediaTest.swift; sourceTree = "<group>"; };
 		CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCAudioTest.swift; sourceTree = "<group>"; };
+		CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaListTest.swift; sourceTree = "<group>"; };
 		D2AAC07E0554694100DB518D /* libMobileVLCKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobileVLCKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -914,6 +917,7 @@
 			isa = PBXGroup;
 			children = (
 				CA5D5787210B16960099D6D0 /* VLCMediaThumbnailerTest.swift */,
+				CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */,
 				CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */,
 				CABEDAB721095242005FED09 /* VLCLibraryTest.swift */,
 				CAA9F00120D254A600CDBB2C /* VLCTimeTest.swift */,
@@ -1334,6 +1338,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CABF4D4120D8DBA900FCCE29 /* VLCMediaTest.swift in Sources */,
+				CABEDACB210996D9005FED09 /* VLCMediaListTest.swift in Sources */,
 				CA7BC89120F4419E00C86820 /* XCTestHelper.swift in Sources */,
 				CA5D5788210B16960099D6D0 /* VLCMediaThumbnailerTest.swift in Sources */,
 				CAA9F00320D254AB00CDBB2C /* VLCTimeTest.swift in Sources */,
@@ -1348,6 +1353,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CABF4D4220D8DBA900FCCE29 /* VLCMediaTest.swift in Sources */,
+				CABEDACC210996D9005FED09 /* VLCMediaListTest.swift in Sources */,
 				CA7BC89520F441B500C86820 /* XCTestHelper.swift in Sources */,
 				CA5D5789210B16960099D6D0 /* VLCMediaThumbnailerTest.swift in Sources */,
 				CAA9F00420D254AC00CDBB2C /* VLCTimeTest.swift in Sources */,

--- a/MobileVLCKit.xcodeproj/project.pbxproj
+++ b/MobileVLCKit.xcodeproj/project.pbxproj
@@ -226,6 +226,8 @@
 		CABF4D4220D8DBA900FCCE29 /* VLCMediaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABF4D4020D8DBA900FCCE29 /* VLCMediaTest.swift */; };
 		CABCBAE220EB0B080040E2F5 /* VLCAudioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */; };
 		CABCBAE320EB0B080040E2F5 /* VLCAudioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */; };
+		CABEDAC9210996D9005FED09 /* VLCMediaListDelegateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDAC7210996D9005FED09 /* VLCMediaListDelegateTest.swift */; };
+		CABEDACA210996D9005FED09 /* VLCMediaListDelegateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDAC7210996D9005FED09 /* VLCMediaListDelegateTest.swift */; };
 		CABEDACB210996D9005FED09 /* VLCMediaListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */; };
 		CABEDACC210996D9005FED09 /* VLCMediaListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */; };
 		CABF4D4520D8DCDD00FCCE29 /* libMobileVLCKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2AAC07E0554694100DB518D /* libMobileVLCKit.a */; };
@@ -489,6 +491,7 @@
 		CABEDAB721095242005FED09 /* VLCLibraryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCLibraryTest.swift; sourceTree = "<group>"; };
 		CABF4D4020D8DBA900FCCE29 /* VLCMediaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCMediaTest.swift; sourceTree = "<group>"; };
 		CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCAudioTest.swift; sourceTree = "<group>"; };
+		CABEDAC7210996D9005FED09 /* VLCMediaListDelegateTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaListDelegateTest.swift; sourceTree = "<group>"; };
 		CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaListTest.swift; sourceTree = "<group>"; };
 		D2AAC07E0554694100DB518D /* libMobileVLCKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMobileVLCKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -917,6 +920,7 @@
 			isa = PBXGroup;
 			children = (
 				CA5D5787210B16960099D6D0 /* VLCMediaThumbnailerTest.swift */,
+				CABEDAC7210996D9005FED09 /* VLCMediaListDelegateTest.swift */,
 				CABEDAC8210996D9005FED09 /* VLCMediaListTest.swift */,
 				CABCBADD20EB0B080040E2F5 /* VLCAudioTest.swift */,
 				CABEDAB721095242005FED09 /* VLCLibraryTest.swift */,
@@ -1341,6 +1345,7 @@
 				CABEDACB210996D9005FED09 /* VLCMediaListTest.swift in Sources */,
 				CA7BC89120F4419E00C86820 /* XCTestHelper.swift in Sources */,
 				CA5D5788210B16960099D6D0 /* VLCMediaThumbnailerTest.swift in Sources */,
+				CABEDAC9210996D9005FED09 /* VLCMediaListDelegateTest.swift in Sources */,
 				CAA9F00320D254AB00CDBB2C /* VLCTimeTest.swift in Sources */,
 				CABCBAE220EB0B080040E2F5 /* VLCAudioTest.swift in Sources */,
 				CABEDAB821095242005FED09 /* VLCLibraryTest.swift in Sources */,
@@ -1356,6 +1361,7 @@
 				CABEDACC210996D9005FED09 /* VLCMediaListTest.swift in Sources */,
 				CA7BC89520F441B500C86820 /* XCTestHelper.swift in Sources */,
 				CA5D5789210B16960099D6D0 /* VLCMediaThumbnailerTest.swift in Sources */,
+				CABEDACA210996D9005FED09 /* VLCMediaListDelegateTest.swift in Sources */,
 				CAA9F00420D254AC00CDBB2C /* VLCTimeTest.swift in Sources */,
 				CABCBAE320EB0B080040E2F5 /* VLCAudioTest.swift in Sources */,
 				CABEDAB921095242005FED09 /* VLCLibraryTest.swift in Sources */,

--- a/Tests/Helper/Video.swift
+++ b/Tests/Helper/Video.swift
@@ -37,8 +37,6 @@ struct Video {
         let bundle = Bundle(identifier: "org.videolan.TVVLCKitTests")!
     #endif
     
-    static let standards = [Video.test1, Video.test2, Video.test3, Video.test4]
-    
     static let test1 = Video(
         name: "bird",
         type: "m4v",

--- a/Tests/Sources/VLCMediaListDelegateTest.swift
+++ b/Tests/Sources/VLCMediaListDelegateTest.swift
@@ -76,7 +76,8 @@ class VLCMediaListDelegateTest: XCTestCase {
             (10, 0, false),
         ]
         
-        let source = Video.standards.map{ VLCMedia(path: $0.path) }
+        let videos = [Video.test1, Video.test2, Video.test3, Video.test4]
+        let source = videos.map{ VLCMedia(path: $0.path) }
         let mediaList = try XCTAssertNotNilAndUnwrap(VLCMediaList(array: source))
 
         for (deleteIdx, count, removalSuccessful) in tests {

--- a/Tests/Sources/VLCMediaListDelegateTest.swift
+++ b/Tests/Sources/VLCMediaListDelegateTest.swift
@@ -1,0 +1,99 @@
+/*****************************************************************************
+ * VLCMediaListDelegateTest.swift
+ *****************************************************************************
+ * Copyright (C) 2018 Mike JS. Choi
+ * Copyright (C) 2018 VLC authors and VideoLAN
+ * $Id$
+ *
+ * Authors: Mike JS. Choi <mkchoi212 # icloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+ *****************************************************************************/
+
+import XCTest
+
+final class MockMediaListDelegate: NSObject, VLCMediaListDelegate {
+    var removedIdx: UInt?
+    var removedExpectation: XCTestExpectation?
+    
+    func mediaList(_ aMediaList: VLCMediaList!, mediaRemovedAt index: UInt) {
+        removedIdx = index
+        removedExpectation?.fulfill()
+    }
+}
+
+class VLCMediaListDelegateTest: XCTestCase {
+    
+    // MARK: Delegate callbacks
+    
+    func testMediaRemovedAt() throws {
+        let videos = [Video.test1, Video.test2, Video.test3, Video.test4]
+        let source = videos.map{ VLCMedia(path: $0.path) }
+        let mediaList = try XCTAssertNotNilAndUnwrap(VLCMediaList(array: source))
+        
+        let delegate = MockMediaListDelegate()
+        mediaList.delegate = delegate
+        
+        for idx in stride(from: UInt(source.count - 1), to: 0, by: -1) {
+            let delegateCalled = expectation(description: "delegate::mediaRemovedAt called")
+            delegate.removedExpectation = delegateCalled
+            
+            let oldCount = mediaList.count
+            
+            // Remove media from list
+            let ok = mediaList.removeMedia(at: idx)
+            XCTAssertTrue(ok)
+            
+            wait(for: [delegateCalled], timeout: STANDARD_TIME_OUT)
+            
+            XCTAssertEqual(delegate.removedIdx, idx)
+            XCTAssertEqual(mediaList.count, oldCount - 1)
+        }
+    }
+    
+    // MARK: Notification
+
+    func testMediaItemDeletedNotification() throws {
+        let tests: [(deleteIdx: UInt, count: Int, removalSuccessful: Bool)] = [
+            (9,  4, false),
+            (3,  3, true),
+            (1,  2, true),
+            (99, 2, false),
+            (1,  1, true),
+            (0,  0, true),
+            (10, 0, false),
+        ]
+        
+        let source = Video.standards.map{ VLCMedia(path: $0.path) }
+        let mediaList = try XCTAssertNotNilAndUnwrap(VLCMediaList(array: source))
+
+        for (deleteIdx, count, removalSuccessful) in tests {
+            let removalResult = mediaList.removeMedia(at: deleteIdx)
+            XCTAssertEqual(removalResult, removalSuccessful)
+            
+            if removalSuccessful {
+                let deleteNotification = NSNotification.Name(rawValue: VLCMediaListItemDeleted)
+                let internalListChanged = expectation(forNotification: deleteNotification, object: mediaList) { notification in
+                    guard let idx = notification.userInfo?["index"] as? NSNumber else {
+                        return false
+                    }
+                    return idx.int64Value == deleteIdx && mediaList.count == count
+                }
+                
+                wait(for: [internalListChanged], timeout: STANDARD_TIME_OUT)
+            }
+        }
+    }
+}

--- a/Tests/Sources/VLCMediaListTest.swift
+++ b/Tests/Sources/VLCMediaListTest.swift
@@ -1,0 +1,55 @@
+/*****************************************************************************
+ * VLCMediaListTest.swift
+ *****************************************************************************
+ * Copyright (C) 2018 Mike JS. Choi
+ * Copyright (C) 2018 VLC authors and VideoLAN
+ * $Id$
+ *
+ * Authors: Mike JS. Choi <mkchoi212 # icloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+ *****************************************************************************/
+
+import XCTest
+
+class VLCMediaListTest: XCTestCase {
+
+    func testRemoveMedia() throws {
+        let videos = [Video.test1, Video.test1, Video.test2, Video.test3, Video.test4, Video.test4]
+        let source = videos.map{ $0.media }
+        let mediaList = try XCTAssertNotNilAndUnwrap(VLCMediaList(array: source))
+        
+        let NF = UInt(NSNotFound)
+        let tests: [(targetIdx: UInt, expectedState: [UInt], ok: Bool)] = [
+            (0, [NF, 0, 1, 2, 3, 4], true),
+            (3, [NF, 0, 1, 2,NF, 3], true),
+            (9, [NF, 0, 1, 2,NF, 3], false),
+            (2, [NF, 0, 1,NF,NF, 2], true),
+            (1, [NF, 0,NF,NF,NF, 1], true),
+            (8, [NF, 0,NF,NF,NF, 1], false),
+            (0, [NF,NF,NF,NF,NF, 0], true),
+            (0, [NF,NF,NF,NF,NF,NF], true),
+            (6, [NF,NF,NF,NF,NF,NF], false)
+        ]
+        
+        for (targetIdx, expectedState, ok) in tests {
+            let removalResult = mediaList.removeMedia(at: targetIdx)
+            let currentState = source.map{ mediaList.index(of: $0) }
+            
+            XCTAssertEqual(removalResult, ok)
+            XCTAssertEqual(currentState, expectedState)
+        }
+    }
+}

--- a/Tests/Sources/VLCMediaThumbnailerTest.swift
+++ b/Tests/Sources/VLCMediaThumbnailerTest.swift
@@ -43,7 +43,8 @@ class VLCMediaThumbnailerTest: XCTestCase {
     // MARK: Initializers
     
     func testInitWithMediaAndDelegate() throws {
-        let tests = Video.standards.map{ $0.media }
+        let videos = [Video.test1, Video.test2, Video.test3, Video.test4]
+        let tests = videos.map{ $0.media }
         
         for media in tests {
             let delegate = MockThumbnailerDelegate()

--- a/VLCKit.xcodeproj/project.pbxproj
+++ b/VLCKit.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		CA766ED620E9E53E009B3F3F /* VLCAudioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA766ED520E9E53E009B3F3F /* VLCAudioTest.swift */; };
 		CA7BC8B720F4424100C86820 /* XCTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7BC8B020F4424100C86820 /* XCTestHelper.swift */; };
 		CABEDABB2109525B005FED09 /* VLCLibraryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDABA2109525B005FED09 /* VLCLibraryTest.swift */; };
+		CABEDABE21095BBD005FED09 /* VLCMediaListDelegateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDABC21095BBD005FED09 /* VLCMediaListDelegateTest.swift */; };
 		CABEDABF21095BBD005FED09 /* VLCMediaListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDABD21095BBD005FED09 /* VLCMediaListTest.swift */; };
 		CABF4D5420D8E31700FCCE29 /* VLCMediaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABF4D5320D8E31700FCCE29 /* VLCMediaTest.swift */; };
 /* End PBXBuildFile section */
@@ -226,6 +227,7 @@
 		CA766ED520E9E53E009B3F3F /* VLCAudioTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCAudioTest.swift; sourceTree = "<group>"; };
 		CA7BC8B020F4424100C86820 /* XCTestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestHelper.swift; sourceTree = "<group>"; };
 		CABEDABA2109525B005FED09 /* VLCLibraryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCLibraryTest.swift; sourceTree = "<group>"; };
+		CABEDABC21095BBD005FED09 /* VLCMediaListDelegateTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaListDelegateTest.swift; sourceTree = "<group>"; };
 		CABEDABD21095BBD005FED09 /* VLCMediaListTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaListTest.swift; sourceTree = "<group>"; };
 		CABF4D5320D8E31700FCCE29 /* VLCMediaTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaTest.swift; sourceTree = "<group>"; };
 		CCEC5B73114D9BE800D34AAB /* deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = deprecated.h; path = libvlc/vlc/include/vlc/deprecated.h; sourceTree = SOURCE_ROOT; };
@@ -536,6 +538,7 @@
 			children = (
 				CABEDABA2109525B005FED09 /* VLCLibraryTest.swift */,
 				CA6F70B2210AD41400FADCAB /* VLCMediaThumbnailerTest.swift */,
+				CABEDABC21095BBD005FED09 /* VLCMediaListDelegateTest.swift */,
 				CABEDABD21095BBD005FED09 /* VLCMediaListTest.swift */,
 				CABF4D5320D8E31700FCCE29 /* VLCMediaTest.swift */,
 				CA766ED520E9E53E009B3F3F /* VLCAudioTest.swift */,
@@ -845,6 +848,7 @@
 				CA6F70B3210AD41400FADCAB /* VLCMediaThumbnailerTest.swift in Sources */,
 				CA766ED620E9E53E009B3F3F /* VLCAudioTest.swift in Sources */,
 				CABEDABB2109525B005FED09 /* VLCLibraryTest.swift in Sources */,
+				CABEDABE21095BBD005FED09 /* VLCMediaListDelegateTest.swift in Sources */,
 				CA7BC8B720F4424100C86820 /* XCTestHelper.swift in Sources */,
 				CA1E133021087CD60066F32F /* Video.swift in Sources */,
 			);

--- a/VLCKit.xcodeproj/project.pbxproj
+++ b/VLCKit.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		CA766ED620E9E53E009B3F3F /* VLCAudioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA766ED520E9E53E009B3F3F /* VLCAudioTest.swift */; };
 		CA7BC8B720F4424100C86820 /* XCTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7BC8B020F4424100C86820 /* XCTestHelper.swift */; };
 		CABEDABB2109525B005FED09 /* VLCLibraryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDABA2109525B005FED09 /* VLCLibraryTest.swift */; };
+		CABEDABF21095BBD005FED09 /* VLCMediaListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABEDABD21095BBD005FED09 /* VLCMediaListTest.swift */; };
 		CABF4D5420D8E31700FCCE29 /* VLCMediaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABF4D5320D8E31700FCCE29 /* VLCMediaTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -225,6 +226,7 @@
 		CA766ED520E9E53E009B3F3F /* VLCAudioTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCAudioTest.swift; sourceTree = "<group>"; };
 		CA7BC8B020F4424100C86820 /* XCTestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestHelper.swift; sourceTree = "<group>"; };
 		CABEDABA2109525B005FED09 /* VLCLibraryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCLibraryTest.swift; sourceTree = "<group>"; };
+		CABEDABD21095BBD005FED09 /* VLCMediaListTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaListTest.swift; sourceTree = "<group>"; };
 		CABF4D5320D8E31700FCCE29 /* VLCMediaTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VLCMediaTest.swift; sourceTree = "<group>"; };
 		CCEC5B73114D9BE800D34AAB /* deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = deprecated.h; path = libvlc/vlc/include/vlc/deprecated.h; sourceTree = SOURCE_ROOT; };
 		CCEC5B74114D9BE800D34AAB /* libvlc_events.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libvlc_events.h; path = libvlc/vlc/include/vlc/libvlc_events.h; sourceTree = SOURCE_ROOT; };
@@ -534,6 +536,7 @@
 			children = (
 				CABEDABA2109525B005FED09 /* VLCLibraryTest.swift */,
 				CA6F70B2210AD41400FADCAB /* VLCMediaThumbnailerTest.swift */,
+				CABEDABD21095BBD005FED09 /* VLCMediaListTest.swift */,
 				CABF4D5320D8E31700FCCE29 /* VLCMediaTest.swift */,
 				CA766ED520E9E53E009B3F3F /* VLCAudioTest.swift */,
 				CA23EBCB20BDF07700C0D635 /* VLCTimeTest.swift */,
@@ -837,6 +840,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CABF4D5420D8E31700FCCE29 /* VLCMediaTest.swift in Sources */,
+				CABEDABF21095BBD005FED09 /* VLCMediaListTest.swift in Sources */,
 				CA23EBCC20BDF07700C0D635 /* VLCTimeTest.swift in Sources */,
 				CA6F70B3210AD41400FADCAB /* VLCMediaThumbnailerTest.swift in Sources */,
 				CA766ED620E9E53E009B3F3F /* VLCAudioTest.swift in Sources */,


### PR DESCRIPTION
Includes tests for #34 `VLCMediaList::removeMediaAt`
Needs to be rebased after #34 