### PR TITLE
VLCMedia: fix mediaWithURL redundant encoding (closes #139)

### DIFF
--- a/Sources/VLCMedia.m
+++ b/Sources/VLCMedia.m
@@ -269,13 +269,7 @@ static void HandleMediaParsedChanged(const libvlc_event_t * event, void * self)
         const char *url;
         VLCLibrary *library = [VLCLibrary sharedLibrary];
         NSAssert(library.instance, @"no library instance when creating media");
-
-        if (([[anURL absoluteString] hasPrefix:@"sftp://"]) ||
-            ([[anURL absoluteString] hasPrefix:@"smb://"])) {
-            url = [[[anURL absoluteString] stringByRemovingPercentEncoding] UTF8String];
-        } else {
-            url = [[anURL absoluteString] UTF8String];
-        }
+        url = [[[anURL absoluteString] stringByRemovingPercentEncoding] UTF8String];
 
         p_md = libvlc_media_new_location(library.instance, url);
 

--- a/Tests/Sources/VLCMediaTest.swift
+++ b/Tests/Sources/VLCMediaTest.swift
@@ -38,4 +38,41 @@ class VLCMediaTest: XCTestCase {
             XCTAssertEqual(expected, actual, input)
         }
     }
+    
+    func testInitWithUrl() throws {
+        let tests = [
+            "sftp://dummypath.mov",
+            "smb://dummypath.mkv",
+            "http://www.xyz.com/我们走吧.mp3".encodeURL(),
+            "smb://server/가즈아.mp3".encodeURL(),
+            "smb://server/media file.mp3".encodeURL()
+        ]
+        
+        for path in tests {
+            let url = try XCTAssertNotNilAndUnwrap(URL(string: path))
+            let media = VLCMedia(url: url)
+            XCTAssertEqual(media.url, url)
+            media.verify(type: .file)
+        }
+    }
+}
+
+extension VLCMedia {
+    func verify(type: VLCMediaType,file: StaticString = #file, line: UInt = #line) {
+        XCTAssertNotNil(metaDictionary, file: file, line: line)
+        XCTAssertNotNil(subitems, file: file, line: line)
+        XCTAssertNotNil(url, file: file, line: line)
+        XCTAssertEqual(mediaType, type, file: file, line: line)
+        XCTAssertEqual(state, VLCMediaState.nothingSpecial, file: file, line: line)
+    }
+}
+
+extension String {
+    func encodeURL() -> String {
+        guard let encoded = addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) else {
+            XCTFail("Failed to encode URL \(self)")
+            return ""
+        }
+        return encoded
+    }
 }


### PR DESCRIPTION
Gitlab [Issue](https://code.videolan.org/videolan/VLCKit/issues/139)

PR **checks if the provided url has been already encoded** to prevent redundant url encoding.