### PR TITLE
Fixed issue of initializing VLCMedia with already opened stream

### DIFF
--- a/Headers/Public/VLCMedia.h
+++ b/Headers/Public/VLCMedia.h
@@ -168,7 +168,6 @@ typedef NS_ENUM(NSInteger, VLCMediaState) {
  * This subclass must allow setting NSStreamFileCurrentOffsetKey property.
  * \note VLCMedia will open stream if it is not already opened, and will close eventually.
  * You can't pass an already closed input stream.
- * \note VLCHTTPInputStream instance can be passed in order to stream remote media.
  * \param stream Input stream for media to be accessed.
  * \return A new VLCMedia object, only if there were no errors.
  */

--- a/Sources/VLCMedia.m
+++ b/Sources/VLCMedia.m
@@ -70,14 +70,16 @@ NSString *const VLCMediaMetaChanged              = @"VLCMediaMetaChanged";
 int open_cb(void *opaque, void **datap, uint64_t *sizep) {
     NSInputStream *stream = (__bridge NSInputStream *)(opaque);
     
+    *datap = opaque;
+    *sizep = UINT64_MAX;
+    
     // Once a stream is closed, it cannot be reopened.
     if (stream && stream.streamStatus == NSStreamStatusNotOpen) {
         [stream open];
-        *datap = opaque;
-        *sizep = UINT64_MAX;
         return 0;
+    } else {
+        return stream.streamStatus == NSStreamStatusOpen ? 0 : -1;
     }
-    return stream.streamStatus == NSStreamStatusOpen ? 0 : -1;
 }
 
 ssize_t read_cb(void *opaque, unsigned char *buf, size_t len) {


### PR DESCRIPTION
Pointer to `NSInputStream` was not passed to `open_cb`'s `opaque` parameter when stream is already opened by user.
Also removed reference to non-existing VLCHTTPInputStream