### PR TITLE
Enabling iOS bitcode

### DIFF
--- a/MobileVLCKit.xcodeproj/project.pbxproj
+++ b/MobileVLCKit.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		7D797FC21DF41F4900AD93ED /* DynamicTVVLCKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D797FC11DF41F4900AD93ED /* DynamicTVVLCKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D797FC41DF41F9100AD93ED /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D797FC31DF41F9100AD93ED /* libc++.tbd */; };
 		7D797FC61DF41F9500AD93ED /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D797FC51DF41F9500AD93ED /* libiconv.tbd */; };
-		7D797FC81DF41FB900AD93ED /* DynamicMobileVLCKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D797FC71DF41FB900AD93ED /* DynamicMobileVLCKit.h */; };
+		7D797FC81DF41FB900AD93ED /* DynamicMobileVLCKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D797FC71DF41FB900AD93ED /* DynamicMobileVLCKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D803EB61C8F21D200864A9C /* VLCDialogProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D803EB51C8F21D200864A9C /* VLCDialogProvider.m */; };
 		7D803EC01C8F2AB400864A9C /* VLCEmbeddedDialogProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D803EBE1C8F2AB400864A9C /* VLCEmbeddedDialogProvider.m */; };
 		7D803EC11C8F2AB400864A9C /* VLCEmbeddedDialogProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D803EBE1C8F2AB400864A9C /* VLCEmbeddedDialogProvider.m */; };
@@ -1587,7 +1587,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1608,12 +1607,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-read_only_relocs",
-					suppress,
-				);
-				OTHER_LIBTOOLFLAGS = "-read_only_relocs suppress";
+				"OTHER_LIBTOOLFLAGS[arch=*]" = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1649,7 +1643,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1677,12 +1670,12 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
 					"-ObjC",
 					"-read_only_relocs",
 					suppress,
 				);
-				OTHER_LIBTOOLFLAGS = "-read_only_relocs suppress";
+				"OTHER_LIBTOOLFLAGS[sdk=iphonesimulator*]" = "-read_only_relocs suppress";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
This PR does two things:

- Enables bitcode for `DynamicMobileVLCKit` target.
- Makes `DynamicMobileVLCKit.h` public.

Bitcode and `-read_only_relocs` flag are incompatible when compiling framework for iOS device thus we have limited it to simulator only.