### PR TITLE
VLCCustomDialogProvider: Fix typo in updateProgressWithReference

### DIFF
--- a/Headers/Public/VLCDialogProvider.h
+++ b/Headers/Public/VLCDialogProvider.h
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSUInteger, VLCDialogQuestionType) {
  */
 - (void)updateProgressWithReference:(NSValue * _Nonnull)reference
                             message:(NSString * _Nullable)message
-                            postion:(float)position;
+                            position:(float)position;
 
 /** VLC decided to destroy a dialog
  * \param reference to the dialog to destroy

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Version 3.2.0:
 --------------
 - Enabled libmux module
 
+- API Changes:
+    - updateProgressWithReference:message:postion: to updateProgressWithReference:message:position:
+
 - new recording Api
 VLCMediaPlayerDelegate:
 	- (void)mediaPlayerStartedRecording:(VLCMediaPlayer *)player;

--- a/Sources/VLCCustomDialogProvider.m
+++ b/Sources/VLCCustomDialogProvider.m
@@ -264,10 +264,10 @@ static void updateProgressCallback(void *p_data,
         return;
     }
 
-    if ([self.customRenderer respondsToSelector:@selector(updateProgressWithReference:message:postion:)]) {
+    if ([self.customRenderer respondsToSelector:@selector(updateProgressWithReference:message:position:)]) {
         [self.customRenderer updateProgressWithReference:dialogData[0]
                                                  message:dialogData[1]
-                                                 postion:[dialogData[2] floatValue]];
+                                                 position:[dialogData[2] floatValue]];
     }
 }
 


### PR DESCRIPTION
Fix small typo in `updateProgressWithReference`