### PR TITLE
VLCCustomDialogProvider: Send correct parameter

### DIFF
--- a/Sources/VLCCustomDialogProvider.m
+++ b/Sources/VLCCustomDialogProvider.m
@@ -136,8 +136,8 @@ static void updateProgressCallback(void *p_data,
         VLCCustomDialogProvider *dialogProvider = (__bridge VLCCustomDialogProvider *)p_data;
         [dialogProvider performSelectorOnMainThread:@selector(updateDisplayedProgressDialog:)
                                          withObject:@[[NSValue valueWithPointer:p_id],
-                                                      @(f_position),
-                                                      toNSStr(psz_text)]
+                                                      toNSStr(psz_text),
+                                                      @(f_position)]
                                       waitUntilDone:NO];
     }
 }


### PR DESCRIPTION
closes [#199](https://code.videolan.org/videolan/VLCKit/issues/199).