### PR TITLE
Xcode: MobileVLCKit: Build with dSYM file only on release

### DIFF
--- a/MobileVLCKit.xcodeproj/project.pbxproj
+++ b/MobileVLCKit.xcodeproj/project.pbxproj
@@ -1558,6 +1558,7 @@
 				);
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DSTROOT = /tmp/MobileVLCKit.dst;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;


### PR DESCRIPTION
By default, in a debug we shouldn't need to build with a dSYM file.
This should speed up the overall MobileVLCKit build time.