### PR TITLE
VLCMediaPlayer: VLCMediaPlayerStateToString: Return ES Added

### DIFF
--- a/Sources/VLCMediaPlayer.m
+++ b/Sources/VLCMediaPlayer.m
@@ -74,7 +74,8 @@ NSString * VLCMediaPlayerStateToString(VLCMediaPlayerState state)
         [VLCMediaPlayerStateEnded]        = @"VLCMediaPlayerStateEnded",
         [VLCMediaPlayerStateError]        = @"VLCMediaPlayerStateError",
         [VLCMediaPlayerStatePlaying]      = @"VLCMediaPlayerStatePlaying",
-        [VLCMediaPlayerStatePaused]       = @"VLCMediaPlayerStatePaused"
+        [VLCMediaPlayerStatePaused]       = @"VLCMediaPlayerStatePaused",
+        [VLCMediaPlayerStateESAdded]      = @"VLCMediaPlayerStateESAdded"
     };
     return stateToStrings[state];
 }


### PR DESCRIPTION
Return`VLCMediaPlayerStateESAdded` also in order to be in sync with the enum.
