### PR TITLE
VLCLibrary: Simplify HandleMessage

### DIFF
--- a/Sources/VLCLibrary.m
+++ b/Sources/VLCLibrary.m
@@ -206,17 +206,9 @@ static void HandleMessage(void *data,
         return;
 
     char *str;
-    if (vasprintf(&str, fmt, args) == -1) {
-        if (str)
-            free(str);
-        str = NULL;
-        return;
+
+    if (vasprintf(&str, fmt, args) != -1) {
+        VKLog(@"%s", str);
+        free(str);
     }
-
-    if (str == NULL)
-        return;
-
-    VKLog(@"%s", str);
-    free(str);
-    str = NULL;
 }


### PR DESCRIPTION
From man: vasprintf() will return -1 and set ret to be a NULL pointer.