### PR TITLE
MediaPlayer: expose callback, rename callback

### DIFF
--- a/Headers/Public/VLCMediaPlayer.h
+++ b/Headers/Public/VLCMediaPlayer.h
@@ -147,7 +147,7 @@ extern NSString * VLCMediaPlayerStateToString(VLCMediaPlayerState state);
  * @param player the player who stopped recording
  * @param path the path to the file that the player recorded to
  */
-- (void)mediaPlayer:(VLCMediaPlayer *)player recordStoppedAtPath:(NSString *)path;
+- (void)mediaPlayer:(VLCMediaPlayer *)player recordingStoppedAtPath:(NSString *)path;
 
 @end
 

--- a/Sources/VLCMediaPlayer.m
+++ b/Sources/VLCMediaPlayer.m
@@ -96,6 +96,7 @@ NSString * VLCMediaPlayerStateToString(VLCMediaPlayerState state)
 - (void)mediaPlayerChapterChanged:(NSNumber *)newChapter;
 
 - (void)mediaPlayerSnapshot:(NSString *)fileName;
+- (void)mediaPlayerRecordChanged:(NSArray *)arguments;
 @end
 
 static void HandleMediaTimeChanged(const libvlc_event_t * event, void * self)
@@ -1548,7 +1549,7 @@ static void HandleMediaPlayerRecord(const libvlc_event_t * event, void * self)
     BOOL isRecording = [arguments.firstObject[@"isRecording"] boolValue];
 
     isRecording ? [_delegate mediaPlayerStartedRecording:self]
-                : [_delegate mediaPlayer:self recordStoppedAtPath:filePath];
+                : [_delegate mediaPlayer:self recordingStoppedAtPath:filePath];
 }
 
 @end


### PR DESCRIPTION
mediaPlayerRecordChanged was not exposed which resulted in a warning
and recordStoppedAtPath -> recordingStoppedAtPath for consistency

