### PR TITLE
Bump libvlc and patchset to `70073ce949`

### DIFF
--- a/Resources/MobileVLCKit/patches/0001-arm_neon-work-around-libtool-issue.patch
+++ b/Resources/MobileVLCKit/patches/0001-arm_neon-work-around-libtool-issue.patch
@@ -1,4 +1,4 @@
-From f722ec6e0a507d9d6ac8d07b64d397e0005f7d36 Mon Sep 17 00:00:00 2001
+From dc9c618b4c6688c6513b5cae8904e37c7e2660ac Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <fkuehne@videolan.org>
 Date: Thu, 18 Dec 2014 22:14:55 +0100
 Subject: [PATCH 01/24] arm_neon: work-around libtool issue

--- a/Resources/MobileVLCKit/patches/0002-disable-neon-volume-plugin.patch
+++ b/Resources/MobileVLCKit/patches/0002-disable-neon-volume-plugin.patch
@@ -1,4 +1,4 @@
-From ec0833dc5c0de67ccb70aaad13b5cca1b53b2b63 Mon Sep 17 00:00:00 2001
+From dbd9f620328f25116a4b566f35874716afacc0b5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <fkuehne@videolan.org>
 Date: Wed, 10 Dec 2014 22:14:55 +0100
 Subject: [PATCH 02/24] disable neon volume plugin

--- a/Resources/MobileVLCKit/patches/0003-Enable-System-DL.patch
+++ b/Resources/MobileVLCKit/patches/0003-Enable-System-DL.patch
@@ -1,4 +1,4 @@
-From e212978e2104a3b1b63c26a7844039d04ee2a3d1 Mon Sep 17 00:00:00 2001
+From fd74fd58538a01d109f0f3a26df781e19c1fc528 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <fkuehne@videolan.org>
 Date: Fri, 22 Jul 2016 11:11:44 +0200
 Subject: [PATCH 03/24] Enable System DL

--- a/Resources/MobileVLCKit/patches/0004-http-add-vlc_http_cookies_clear.patch
+++ b/Resources/MobileVLCKit/patches/0004-http-add-vlc_http_cookies_clear.patch
@@ -1,4 +1,4 @@
-From a6aab77007bd9037311dd318e7d0f6731a2d072c Mon Sep 17 00:00:00 2001
+From 65a2faaf03bf4069e0b30c6ffd496a82f9deaa70 Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Fri, 16 Sep 2016 15:51:10 +0200
 Subject: [PATCH 04/24] http: add vlc_http_cookies_clear

--- a/Resources/MobileVLCKit/patches/0005-libvlc_media-add-cookie_jar-API.patch
+++ b/Resources/MobileVLCKit/patches/0005-libvlc_media-add-cookie_jar-API.patch
@@ -1,4 +1,4 @@
-From 7ea0717450762464b257e5ee36624871a96b1d74 Mon Sep 17 00:00:00 2001
+From 9f094b23210393814b6c6b58b412bf2535bfd7e7 Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Fri, 16 Sep 2016 15:51:11 +0200
 Subject: [PATCH 05/24] libvlc_media: add cookie_jar API

--- a/Resources/MobileVLCKit/patches/0006-contrib-gcrypt-work-around-a-libtool-limitation.patch
+++ b/Resources/MobileVLCKit/patches/0006-contrib-gcrypt-work-around-a-libtool-limitation.patch
@@ -1,4 +1,4 @@
-From 20fc6522b5fdc3b2e9cd43c20365e0449bf7370e Mon Sep 17 00:00:00 2001
+From 6919eee7ec517745c48aec19e8b2d82ba14e9b85 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <fkuehne@videolan.org>
 Date: Sun, 7 Dec 2014 20:02:18 +0100
 Subject: [PATCH 06/24] contrib/gcrypt: work-around a libtool limitation
@@ -10,7 +10,7 @@ Subject: [PATCH 06/24] contrib/gcrypt: work-around a libtool limitation
  create mode 100644 contrib/src/gcrypt/work-around-libtool-limitation.patch
 
 diff --git a/contrib/src/gcrypt/rules.mak b/contrib/src/gcrypt/rules.mak
-index eb1debac1b..bc938e585f 100644
+index 0e45004c30..4bc68ce60f 100644
 --- a/contrib/src/gcrypt/rules.mak
 +++ b/contrib/src/gcrypt/rules.mak
 @@ -12,6 +12,7 @@ $(TARBALLS)/libgcrypt-$(GCRYPT_VERSION).tar.bz2:
@@ -19,8 +19,8 @@ index eb1debac1b..bc938e585f 100644
  	$(APPLY) $(SRC)/gcrypt/disable-tests-compilation.patch
 +	$(APPLY) $(SRC)/gcrypt/work-around-libtool-limitation.patch
  	$(APPLY) $(SRC)/gcrypt/fix-pthread-detection.patch
- ifdef HAVE_WINSTORE
- 	$(APPLY) $(SRC)/gcrypt/winrt.patch
+ 	$(APPLY) $(SRC)/gcrypt/0001-random-Don-t-assume-that-_WIN64-implies-x86_64.patch
+ 	$(APPLY) $(SRC)/gcrypt/0002-aarch64-mpi-Fix-building-the-mpi-aarch64-assembly-fo.patch
 diff --git a/contrib/src/gcrypt/work-around-libtool-limitation.patch b/contrib/src/gcrypt/work-around-libtool-limitation.patch
 new file mode 100644
 index 0000000000..df97ffb488

--- a/Resources/MobileVLCKit/patches/0007-contrib-gcrypt-fix-tvOS-compilation.patch
+++ b/Resources/MobileVLCKit/patches/0007-contrib-gcrypt-fix-tvOS-compilation.patch
@@ -1,4 +1,4 @@
-From 56de0725dec3e6bbb1e7c50bbdd27e6f71c9c1fe Mon Sep 17 00:00:00 2001
+From 3cc76553965aac561acdca22134e039e186263cf Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <fkuehne@videolan.org>
 Date: Sat, 3 Oct 2015 22:45:14 +0200
 Subject: [PATCH 07/24] contrib/gcrypt: fix tvOS compilation
@@ -32,7 +32,7 @@ index 0000000000..f1d3ccc71f
 +    *	%rdi: ctx, CTX
 +    *	%rsi: data (64 bytes)
 diff --git a/contrib/src/gcrypt/rules.mak b/contrib/src/gcrypt/rules.mak
-index bc938e585f..3564fde87b 100644
+index 4bc68ce60f..99e7e93dc6 100644
 --- a/contrib/src/gcrypt/rules.mak
 +++ b/contrib/src/gcrypt/rules.mak
 @@ -13,6 +13,7 @@ gcrypt: libgcrypt-$(GCRYPT_VERSION).tar.bz2 .sum-gcrypt
@@ -41,9 +41,9 @@ index bc938e585f..3564fde87b 100644
  	$(APPLY) $(SRC)/gcrypt/work-around-libtool-limitation.patch
 +	$(APPLY) $(SRC)/gcrypt/fix-sha1-ssse3-for-clang.patch
  	$(APPLY) $(SRC)/gcrypt/fix-pthread-detection.patch
- ifdef HAVE_WINSTORE
- 	$(APPLY) $(SRC)/gcrypt/winrt.patch
-@@ -45,6 +46,11 @@ GCRYPT_EXTRA_CFLAGS = -fheinous-gnu-extensions
+ 	$(APPLY) $(SRC)/gcrypt/0001-random-Don-t-assume-that-_WIN64-implies-x86_64.patch
+ 	$(APPLY) $(SRC)/gcrypt/0002-aarch64-mpi-Fix-building-the-mpi-aarch64-assembly-fo.patch
+@@ -47,6 +48,11 @@ GCRYPT_EXTRA_CFLAGS = -fheinous-gnu-extensions
  else
  GCRYPT_EXTRA_CFLAGS =
  endif

--- a/Resources/MobileVLCKit/patches/0008-contrib-gcrypt-update-patches.patch
+++ b/Resources/MobileVLCKit/patches/0008-contrib-gcrypt-update-patches.patch
@@ -1,4 +1,4 @@
-From 7eb426d0b581e6ca258c61185b9b58b75b59069a Mon Sep 17 00:00:00 2001
+From 3471ea78bcb6ddf51cb110e4b2b721052e79dc18 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <fkuehne@videolan.org>
 Date: Mon, 12 Sep 2016 17:03:37 +0200
 Subject: [PATCH 08/24] contrib/gcrypt: update patches

--- a/Resources/MobileVLCKit/patches/0009-Replace-thread-local-with-pthread-TSD.patch
+++ b/Resources/MobileVLCKit/patches/0009-Replace-thread-local-with-pthread-TSD.patch
@@ -1,4 +1,4 @@
-From 3cd38bd0a11400577995f94b10a94ac0d601ddd0 Mon Sep 17 00:00:00 2001
+From 511e7cc46089328eb0017ccb4a43af25b271a68e Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Mon, 17 Jul 2017 17:03:24 +0200
 Subject: [PATCH 09/24] Replace thread local with pthread TSD

--- a/Resources/MobileVLCKit/patches/0010-contrib-use-live555-version-that-is-compatible-with-.patch
+++ b/Resources/MobileVLCKit/patches/0010-contrib-use-live555-version-that-is-compatible-with-.patch
@@ -1,4 +1,4 @@
-From a69b13b0a86f1f74be3b765484e75e6080547fea Mon Sep 17 00:00:00 2001
+From ef3c9b20be99382ef6090f8318cd38736d212f76 Mon Sep 17 00:00:00 2001
 From: Carola Nitz <nitz.carola@googlemail.com>
 Date: Fri, 29 Sep 2017 14:49:02 +0200
 Subject: [PATCH 10/24] contrib: use live555 version that is compatible with
@@ -18,7 +18,7 @@ index f459fb9d16..02b2a69734 100644
 +10846fd6d5482bbea131ae805137077997e9dec242665e3c01d699d5584154c65049e8c520ea855599e554154a148e61fea77b592d97c814a4a98c773658d8f5  live.2016.10.21.tar.gz
 \ No newline at end of file
 diff --git a/contrib/src/live555/rules.mak b/contrib/src/live555/rules.mak
-index 9b275ec33b..30ee48eece 100644
+index e4ed5afb07..f99b7968a4 100644
 --- a/contrib/src/live555/rules.mak
 +++ b/contrib/src/live555/rules.mak
 @@ -1,14 +1,12 @@
@@ -37,7 +37,7 @@ index 9b275ec33b..30ee48eece 100644
  
  ifeq ($(call need_pkg,"live555"),)
  PKGS_FOUND += live555
-@@ -90,7 +88,6 @@ endif
+@@ -92,7 +90,6 @@ endif
  SUBDIRS=groupsock liveMedia UsageEnvironment BasicUsageEnvironment
  
  .live555: live555

--- a/Resources/MobileVLCKit/patches/0011-libvlc-add-a-basic-API-to-change-freetype-s-color-bo.patch
+++ b/Resources/MobileVLCKit/patches/0011-libvlc-add-a-basic-API-to-change-freetype-s-color-bo.patch
@@ -1,4 +1,4 @@
-From fa00abf30e86d629dec8c39049267671ffa93494 Mon Sep 17 00:00:00 2001
+From 7f6b852bf67d88d07cb694778251d35d0a864185 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <felix@feepk.net>
 Date: Sun, 17 Dec 2017 18:05:40 +0100
 Subject: [PATCH 11/24] libvlc: add a basic API to change freetype's color,

--- a/Resources/MobileVLCKit/patches/0012-Work-around-lack-of-__thread-storage-qualifier-on-ol.patch
+++ b/Resources/MobileVLCKit/patches/0012-Work-around-lack-of-__thread-storage-qualifier-on-ol.patch
@@ -1,4 +1,4 @@
-From f48e06d158c35e5546e76e0bfde719f40b540553 Mon Sep 17 00:00:00 2001
+From a01e2597158342b2959e3b541e09cc55f3f3e1ff Mon Sep 17 00:00:00 2001
 From: Carola Nitz <nitz.carola@googlemail.com>
 Date: Fri, 23 Feb 2018 13:16:41 +0100
 Subject: [PATCH 12/24] Work around lack of __thread storage qualifier on old
@@ -14,10 +14,10 @@ Subject: [PATCH 12/24] Work around lack of __thread storage qualifier on old
  rename {compat => src/extras}/tdestroy.c (59%)
 
 diff --git a/configure.ac b/configure.ac
-index cfdae650b3..603b260a73 100644
+index a6ff64595e..b9c2a95c20 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -590,8 +590,8 @@ dnl Check for system libs needed
+@@ -591,8 +591,8 @@ dnl Check for system libs needed
  need_libc=false
  
  dnl Check for usual libc functions
@@ -29,10 +29,10 @@ index cfdae650b3..603b260a73 100644
  AC_CHECK_FUNC(fdatasync,,
    [AC_DEFINE(fdatasync, fsync, [Alias fdatasync() to fsync() if missing.])
 diff --git a/include/vlc_fixups.h b/include/vlc_fixups.h
-index 6c0de2854b..8e8e406028 100644
+index 239cad4d77..e1a1d13e1e 100644
 --- a/include/vlc_fixups.h
 +++ b/include/vlc_fixups.h
-@@ -490,9 +490,12 @@ void *tdelete( const void *key, void **rootp, int(*cmp)(const void *, const void
+@@ -495,9 +495,12 @@ void *tdelete( const void *key, void **rootp, int(*cmp)(const void *, const void
  void twalk( const void *root, void(*action)(const void *nodep, VISIT which, int depth) );
  void *lfind( const void *key, const void *base, size_t *nmemb,
               size_t size, int(*cmp)(const void *, const void *) );

--- a/Resources/MobileVLCKit/patches/0013-modules-common-Use-the-full-module-name-as-MODULE_NA.patch
+++ b/Resources/MobileVLCKit/patches/0013-modules-common-Use-the-full-module-name-as-MODULE_NA.patch
@@ -1,4 +1,4 @@
-From 800d701b0339f6f10f58f0f71fb828c93fe1d4a3 Mon Sep 17 00:00:00 2001
+From bc504873674615f71711747d67103f5f11126930 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo@beauzee.fr>
 Date: Mon, 26 Mar 2018 16:44:44 +0200
 Subject: [PATCH 13/24] modules:common: Use the full module name as MODULE_NAME

--- a/Resources/MobileVLCKit/patches/0014-add-auto-deinterlacer-mode-which-is-also-valid.patch
+++ b/Resources/MobileVLCKit/patches/0014-add-auto-deinterlacer-mode-which-is-also-valid.patch
@@ -1,4 +1,4 @@
-From bde8deaef81276f53e6c0680747ed1f25b564139 Mon Sep 17 00:00:00 2001
+From ff9698b3306cc13be988e27f5c75a7d9f20356d6 Mon Sep 17 00:00:00 2001
 From: Luis Fernandes <zipleen@gmail.com>
 Date: Mon, 30 Apr 2018 14:33:08 +0100
 Subject: [PATCH 14/24] add auto deinterlacer-mode which is also valid

--- a/Resources/MobileVLCKit/patches/0015-Users-will-be-able-to-change-the-deinterlace-mode-wi.patch
+++ b/Resources/MobileVLCKit/patches/0015-Users-will-be-able-to-change-the-deinterlace-mode-wi.patch
@@ -1,4 +1,4 @@
-From d787329479948bbb4e08ccb6ea9fb1363ead5808 Mon Sep 17 00:00:00 2001
+From 1109ec892424828fe9b66cd24faddabe355ab476 Mon Sep 17 00:00:00 2001
 From: Luis Fernandes <zipleen@gmail.com>
 Date: Wed, 9 May 2018 10:44:43 +0100
 Subject: [PATCH 15/24] Users will be able to change the deinterlace mode

--- a/Resources/MobileVLCKit/patches/0016-contrib-ffmpeg-enable-videotoolbox-encoder.patch
+++ b/Resources/MobileVLCKit/patches/0016-contrib-ffmpeg-enable-videotoolbox-encoder.patch
@@ -1,4 +1,4 @@
-From 939e1151740e3abb060a0afeac620a22a0cd70ef Mon Sep 17 00:00:00 2001
+From 5c4577a56a56756f6a30b42b5d724f0ef715c35c Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Tue, 27 Mar 2018 16:49:34 +0200
 Subject: [PATCH 16/24] contrib: ffmpeg: enable videotoolbox encoder

--- a/Resources/MobileVLCKit/patches/0017-chromecast-use-vt-encoder-from-avcodec.patch
+++ b/Resources/MobileVLCKit/patches/0017-chromecast-use-vt-encoder-from-avcodec.patch
@@ -1,4 +1,4 @@
-From a42d5d27f29f6239ee6a874b9a07e675e98fbfa8 Mon Sep 17 00:00:00 2001
+From 3d85f8a44eb9d1d7781ab1c71a0c308f0ebc9ab9 Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Tue, 27 Mar 2018 16:52:35 +0200
 Subject: [PATCH 17/24] chromecast: use vt encoder from avcodec

--- a/Resources/MobileVLCKit/patches/0018-ffmpeg-backport-vtenc-patches.patch
+++ b/Resources/MobileVLCKit/patches/0018-ffmpeg-backport-vtenc-patches.patch
@@ -1,4 +1,4 @@
-From b7ac55bfbc294676bd6ae343a80269f104b4b8d0 Mon Sep 17 00:00:00 2001
+From 87cd7de678ddb793468bd64cbdd0a73158bcc524 Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Mon, 18 Jun 2018 12:31:13 +0200
 Subject: [PATCH 18/24] ffmpeg: backport vtenc patches

--- a/Resources/MobileVLCKit/patches/0019-core-expose-config_AutoSaveConfigFile.patch
+++ b/Resources/MobileVLCKit/patches/0019-core-expose-config_AutoSaveConfigFile.patch
@@ -1,4 +1,4 @@
-From e9af8d3cf8a7d8dc142f09b0b6b500ca36b126d4 Mon Sep 17 00:00:00 2001
+From b1b5cc357d7bea99b2839d1d3ece0e32ae29617a Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Wed, 17 Jan 2018 10:06:13 +0200
 Subject: [PATCH 19/24] core: expose config_AutoSaveConfigFile

--- a/Resources/MobileVLCKit/patches/0020-lib-save-configuration-after-playback-parse.patch
+++ b/Resources/MobileVLCKit/patches/0020-lib-save-configuration-after-playback-parse.patch
@@ -1,4 +1,4 @@
-From 70c8cec5bd26150631b662131ffb65ca6d395a21 Mon Sep 17 00:00:00 2001
+From ba64103e6b1150cdbaced9348507fca2f4ae1164 Mon Sep 17 00:00:00 2001
 From: Thomas Guillem <thomas@gllm.fr>
 Date: Wed, 17 Jan 2018 10:06:13 +0200
 Subject: [PATCH 20/24] lib: save configuration after playback/parse

--- a/Resources/MobileVLCKit/patches/0021-http-access-retain-auth-struct-for-the-runtime-of-th.patch
+++ b/Resources/MobileVLCKit/patches/0021-http-access-retain-auth-struct-for-the-runtime-of-th.patch
@@ -1,4 +1,4 @@
-From b0ef8f7ad8ec99498fcde33989c2765ea2de9069 Mon Sep 17 00:00:00 2001
+From 3effea1cb113a01db0f7b1d39514e5b85153a6ab Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Felix=20Paul=20K=C3=BChne?= <felix@feepk.net>
 Date: Mon, 10 Sep 2018 20:55:11 +0200
 Subject: [PATCH 21/24] http access: retain auth struct for the runtime of the

--- a/Resources/MobileVLCKit/patches/0022-libvlc-media_player-Add-record-method.patch
+++ b/Resources/MobileVLCKit/patches/0022-libvlc-media_player-Add-record-method.patch
@@ -1,4 +1,4 @@
-From 6931f0c66a3978c0c169d8ec8688f1beb7eb3639 Mon Sep 17 00:00:00 2001
+From 87cd0f78e8008894857b55334e3f97ef412fd7f2 Mon Sep 17 00:00:00 2001
 From: Soomin Lee <bubu@mikan.io>
 Date: Wed, 31 Oct 2018 10:08:55 +0100
 Subject: [PATCH 22/24] libvlc: media_player: Add record method
@@ -69,5 +69,5 @@ index 29285065f0..7e714d247b 100644
 +    return VLC_SUCCESS;
 +}
 -- 
-2.17.1
+2.19.1
 

--- a/Resources/MobileVLCKit/patches/0023-libvlc-events-Add-callbacks-for-record.patch
+++ b/Resources/MobileVLCKit/patches/0023-libvlc-events-Add-callbacks-for-record.patch
@@ -1,4 +1,4 @@
-From 8ddb9512335005505493838b105a005b6a7be610 Mon Sep 17 00:00:00 2001
+From ff4255bc853ef1b4026a9dea54cdc55c6ad320da Mon Sep 17 00:00:00 2001
 From: Soomin Lee <bubu@mikan.io>
 Date: Thu, 27 Sep 2018 18:40:39 +0200
 Subject: [PATCH 23/24] libvlc: events: Add callbacks for record
@@ -43,10 +43,10 @@ index f8b0e9b5b2..bbc6bc0eec 100644
          {
              libvlc_renderer_item_t *item;
 diff --git a/lib/media_player.c b/lib/media_player.c
-index 61cc0b0e0d..439910d053 100644
+index 7e714d247b..d76ed7ca56 100644
 --- a/lib/media_player.c
 +++ b/lib/media_player.c
-@@ -446,6 +446,22 @@ input_event_changed( vlc_object_t * p_this, char const * psz_cmd,
+@@ -447,6 +447,22 @@ input_event_changed( vlc_object_t * p_this, char const * psz_cmd,
              }
          }
      }

--- a/Resources/MobileVLCKit/patches/0024-access_output-file-Add-error-dialog-for-write-open.patch
+++ b/Resources/MobileVLCKit/patches/0024-access_output-file-Add-error-dialog-for-write-open.patch
@@ -1,4 +1,4 @@
-From bb6baab0248c4534e25074e5e576c266f00ba057 Mon Sep 17 00:00:00 2001
+From cc310ecf2a4cfe7aad4c363c5acfeb086fe32133 Mon Sep 17 00:00:00 2001
 From: Soomin Lee <bubu@mikan.io>
 Date: Mon, 1 Oct 2018 15:37:57 +0200
 Subject: [PATCH 24/24] access_output: file: Add error dialog for write/open
@@ -8,7 +8,7 @@ Subject: [PATCH 24/24] access_output: file: Add error dialog for write/open
  1 file changed, 8 insertions(+)
 
 diff --git a/modules/access_output/file.c b/modules/access_output/file.c
-index fbefce0be8..a2a72db411 100644
+index fbefce0be8..45de0fc75e 100644
 --- a/modules/access_output/file.c
 +++ b/modules/access_output/file.c
 @@ -88,6 +88,9 @@ static ssize_t Write( sout_access_out_t *p_access, block_t *p_buffer )
@@ -36,5 +36,5 @@ index fbefce0be8..a2a72db411 100644
                  break;
              flags &= ~O_EXCL;
 -- 
-2.19.0
+2.19.1
 

--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -25,7 +25,7 @@ OSVERSIONMINLDFLAG=ios_version_min
 ROOT_DIR=empty
 FARCH="all"
 
-TESTEDHASH="177a4a2a5" # libvlc hash that this version of VLCKit is build on
+TESTEDHASH="70073ce949" # libvlc hash that this version of VLCKit is build on
 
 if [ -z "$MAKE_JOBS" ]; then
     CORE_COUNT=`sysctl -n machdep.cpu.core_count`


### PR DESCRIPTION
Bump libvlc and patchset to `70073ce949` for https://rink.hockeyapp.net/manage/apps/194470/app_versions/113/crash_reasons/242850559.