### PR TITLE
VLCLibrary:Logginglevel was not handled correctly

### DIFF
--- a/Sources/VLCLibrary.m
+++ b/Sources/VLCLibrary.m
@@ -202,7 +202,7 @@ static void HandleMessage(void *data,
 {
     VLCLibrary *libraryInstance = (__bridge VLCLibrary *)data;
 
-    if (level < libraryInstance.debugLoggingLevel)
+    if (level > libraryInstance.debugLoggingLevel)
         return;
 
     char *str;


### PR DESCRIPTION
if you set logging level 4 it would not as expected show all logging messages. This fixes this issue