### PR TITLE
buildMobileVLCKit: write tools variables to config.mak

### DIFF
--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -373,6 +373,13 @@ buildLibVLC() {
 
     echo "EXTRA_CFLAGS += ${EXTRA_CFLAGS}" >> config.mak
     echo "EXTRA_LDFLAGS += ${EXTRA_LDFLAGS}" >> config.mak
+    echo "CC=${CC}" >> config.mak
+    echo "CXX=${CXX}" >> config.mak
+    echo "OBJC=${OBJC}" >> config.mak
+    echo "LD=${LD}" >> config.mak
+    echo "AR=${AR}" >> config.mak
+    echo "RANLIB=${RANLIB}" >> config.mak
+    echo "STRIP=${STRIP}" >> config.mak
     make fetch -j$MAKE_JOBS
     make -j$MAKE_JOBS > ${out}
 


### PR DESCRIPTION
Append tools variables to vlc/contrib/config.mak so that contrib can be build with the same configuration without setting the environment variables again.

This is the beginning of a set of changes  to ease the building of VLCKit. The main goal is to have the same building behaviour as other platforms.

The overall todolist is : 

* [ ] write configuration variable into the different config files used for building (either through ./configure for libvlc or the config.mak for the contribs)
* [ ] avoid using environment variable in the build script, as it might have an unexpected behaviour
* [ ] fix contribs that can build only because the configuration is in the environment variables
* [ ] fix passing options like tv_version_min when it shouldn't be (simulator builds)