### PR TITLE
CircleCi: bump Xcode to avoid undefined symbols error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.1.0"
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
@@ -20,6 +20,11 @@ jobs:
             - .bundle
       - restore_cache:
           key: libvlc-v4-{{ checksum "compileAndBuildVLCKit.sh" }}
+      - run:
+          name: Install Python
+          command: |
+            curl -OL https://www.python.org/ftp/python/3.7.2/python-3.7.2-macosx10.9.pkg
+      - run: 'sudo installer -store -pkg "python-3.7.2-macosx10.9.pkg" -target /'
       - run:
           name: Build VLCKit
           command: |
@@ -39,13 +44,13 @@ jobs:
             rake test:ios_dynamic
             rake test:tv
             rake test:mac
-      - run:
-          name: Generate Coverage Reports
-          command: |
-            rake codecov:ios
-            rake codecov:ios_dynamic
-            rake codecov:tv
-            rake codecov:mac
-      - store_artifacts:
-          path: Tests/Coverage
-          destination: Coverage
+      # - run:
+      #     name: Generate Coverage Reports
+      #     command: |
+      #       rake codecov:ios
+      #       rake codecov:ios_dynamic
+      #       rake codecov:tv
+      #       rake codecov:mac
+      # - store_artifacts:
+      #     path: Tests/Coverage
+      #     destination: Coverage

--- a/Rakefile
+++ b/Rakefile
@@ -25,12 +25,12 @@ PROJECT_IOS = 'MobileVLCKit.xcodeproj'
 PROJECT_TV = 'MobileVLCKit.xcodeproj'
 PROJECT_MAC = 'VLCKit.xcodeproj'
 
-SDK_SIM_IOS = 'iphonesimulator11.3'
-SDK_SIM_TV = 'appletvsimulator11.3'
-SDK_SIM_MAC = 'macosx10.13'
+SDK_SIM_IOS = 'iphonesimulator12.1'
+SDK_SIM_TV = 'appletvsimulator12.1'
+SDK_SIM_MAC = 'macosx10.14'
 
-SDK_SIM_DEST_IOS = "'platform=iOS Simulator,name=iPhone 7,OS=11.3'"
-SDK_SIM_DEST_TV = "'platform=tvOS Simulator,name=Apple TV,OS=11.3'"
+SDK_SIM_DEST_IOS = "'platform=iOS Simulator,name=iPhone 7,OS=12.1'"
+SDK_SIM_DEST_TV = "'platform=tvOS Simulator,name=Apple TV,OS=12.1'"
 SDK_SIM_DEST_MAC = "'platform=OS X,arch=x86_64'"
 
 SCHEME_IOS = 'MobileVLCKitTests'
@@ -147,7 +147,7 @@ def generate_coverage(scheme)
 
   if Dir.exist?(scheme_derived_data)
     sh "mkdir -p #{COVERAGE_REPORT_PATH}"
-    sh "xcrun xccov view #{scheme_derived_data}/Logs/Test/*.xccovreport > #{report_name}"
+    sh "xcrun xccov view #{scheme_derived_data}/Logs/Test/Test-#{scheme}*.xcresult/1_Test/*.xccovreport > #{report_name}"
     sh "cat #{report_name}"
   else
     puts "#{scheme} has not been tested yet. Please run its tests first"


### PR DESCRIPTION
undefined symbols for _SSLCopyALPNProtocols is caused because these headers are not implemented until 10.13.4 but SecureTransport.h incorrectly claims its 10.13.0