### PR TITLE
transcode: fix transcode with passthrough video

### DIFF
--- a/Resources/MobileVLCKit/patches/0025-transcode-add-support-for-mutliple-venc-parameters.patch
+++ b/Resources/MobileVLCKit/patches/0025-transcode-add-support-for-mutliple-venc-parameters.patch
@@ -176,7 +176,8 @@ index c92dd4a974..9009f312bb 100644
 -    es_format_Init( &id->p_encoder->fmt_out, p_fmt->i_cat, 0 );
 -    id->p_encoder->fmt_out.i_id    = p_fmt->i_id;
 -    id->p_encoder->fmt_out.i_group = p_fmt->i_group;
-+    if( p_fmt->i_cat == VIDEO_ES ) //&& p_sys->i_vcodec )
++    if( p_fmt->i_cat == VIDEO_ES &&
++      ( p_sys->i_vcodec || p_sys->pp_vencs.i_size > 0 ) )
 +    {
 +        for( int config_idx=0;
 +             config_idx<p_sys->pp_vencs.i_size;


### PR DESCRIPTION
Fix transcode pipeline when using passthrough for the video track, for
example when using chromecast which doesn't try to convert the video
track.

Thus, it also fixes the playback of correct h264 stream on chromecast.

This was a regression from 553a5da7fe4f63066536ad5522bb0cf754ba8f1b
due to patch transcode-add-support-for-multiple-venc-parameters.