### PR TITLE
Fixed rendererDiscovererItemAdded sending nil item

### DIFF
--- a/Sources/VLCRendererDiscoverer.m
+++ b/Sources/VLCRendererDiscoverer.m
@@ -180,7 +180,7 @@ static void HandleRendererDiscovererItemDeleted(const libvlc_event_t *event, voi
 
     if (!rendererItem) {
         [_rendererItems addObject:item];
-        [_delegate rendererDiscovererItemAdded:self item:rendererItem];
+        [_delegate rendererDiscovererItemAdded:self item:item];
     }
 }
 


### PR DESCRIPTION
The callback was sending the rendererItem which is nil. It should be sending back the item which is not nil.