### PR TITLE
fixes https://code.videolan.org/videolan/VLCKit/-/issues/585

### DIFF
--- a/Sources/VLCMediaPlayer.m
+++ b/Sources/VLCMediaPlayer.m
@@ -488,9 +488,12 @@ static void HandleMediaPlayerRecord(const libvlc_event_t * event, void * self)
 #pragma mark -
 #pragma mark Subtitles
 
-- (void)setCurrentVideoSubTitleIndex:(int)index
-{
-    libvlc_video_set_spu(_playerInstance, index);
+- (void)setCurrentVideoSubTitleIndex:(int)index {
+    if (index == -1) {
+        libvlc_media_player_unselect_track_type(_playerInstance, libvlc_track_text);
+    } else {
+        libvlc_video_set_spu(_playerInstance, index);
+    }
 }
 
 - (int)currentVideoSubTitleIndex


### PR DESCRIPTION
libvlc_video_set_spu does not handle -1 as a call to turn off subtitles, this handles turning them off properly when -1 is passed as a parameter to match the documentation spec.