### PR TITLE
Allow keyboard backlight to shut off during playback

### DIFF
--- a/Sources/Playback/VLCMediaPlayer.m
+++ b/Sources/Playback/VLCMediaPlayer.m
@@ -47,6 +47,7 @@
 #if !TARGET_OS_IPHONE
 /* prevent system sleep */
 # import <CoreServices/CoreServices.h>
+# import <IOKit/pwr_mgt/IOPMLib.h>
 /* FIXME: Ugly hack! */
 # ifdef __x86_64__
 #  import <CoreServices/../Frameworks/OSServices.framework/Headers/Power.h>
@@ -93,6 +94,11 @@ NSString * VLCMediaPlayerStateToString(VLCMediaPlayerState state)
     };
     return stateToStrings[state];
 }
+
+#if !TARGET_OS_IPHONE
+// Display sleep assertion for preventing screen sleep during playback
+static IOPMAssertionID displaySleepAssertion = 0;
+#endif
 
 // TODO: Documentation
 @interface VLCMediaPlayer (Private)
@@ -543,6 +549,9 @@ static void HandleMediaPlayerRecord(const libvlc_event_t * event, void * opaque)
 - (void)dealloc
 {
     [self stopTimeChangeUpdateTimer];
+#if !TARGET_OS_IPHONE
+    [self allowDisplaySleep];
+#endif
     [self unregisterObservers];
 
     // Always get rid of the delegate first so we can stop sending messages to it
@@ -1067,9 +1076,31 @@ static void HandleMediaPlayerRecord(const libvlc_event_t * event, void * opaque)
 #pragma mark playback
 
 #if !TARGET_OS_IPHONE
-- (void)delaySleep
+- (void)preventDisplaySleep
 {
-    UpdateSystemActivity(UsrActivity);
+    if (displaySleepAssertion != 0) return;
+    
+    IOReturn result = IOPMAssertionCreateWithName(
+        kIOPMAssertionTypeNoDisplaySleep,
+        kIOPMAssertionLevelOn,
+        CFSTR("VLC Media Playback"),
+        &displaySleepAssertion
+    );
+    
+    if (result != kIOReturnSuccess) {
+        NSLog(@"[VLCMediaPlayer] Failed to create display sleep assertion: %d", result);
+    }
+}
+
+- (void)allowDisplaySleep
+{
+    if (displaySleepAssertion == 0) return;
+    
+    IOReturn result = IOPMAssertionRelease(displaySleepAssertion);
+    if (result != kIOReturnSuccess) {
+        NSLog(@"[VLCMediaPlayer] Failed to release display sleep assertion: %d", result);
+    }
+    displaySleepAssertion = 0;
 }
 #endif
 
@@ -1101,11 +1132,6 @@ static void HandleMediaPlayerRecord(const libvlc_event_t * event, void * opaque)
     [[NSNotificationCenter defaultCenter] postNotification: notification];
     if ([self.delegate respondsToSelector:@selector(mediaPlayerTimeChanged:)])
         [self.delegate mediaPlayerTimeChanged: notification];
-
-#if !TARGET_OS_IPHONE
-    // This seems to be the most relevant place to delay sleeping and screen saver.
-    [self delaySleep];
-#endif
 
     [self willChangeValueForKey:@"position"];
     [self didChangeValueForKey:@"position"];
@@ -1582,8 +1608,14 @@ static const struct event_handler_entry
     
     if ([self isPlaying]) {
         [self startTimeChangeUpdateTimer];
+#if !TARGET_OS_IPHONE
+        [self preventDisplaySleep];
+#endif
     } else {
         [self stopTimeChangeUpdateTimer];
+#if !TARGET_OS_IPHONE
+        [self allowDisplaySleep];
+#endif
     }
     
     [self didChangeValueForKey:@"state"];


### PR DESCRIPTION
This change updates how the screen is kept on during video playback.

Previously, sleep was prevented by injecting artificial user interaction
on every timeChangeUpdate callback. This successfully keeps the display
from dimming and the computer from going to sleep, but it also prevents
the keyboard backlight from shutting off on laptops that have keyboard
backlights.

This commit uses IOPMAssertionCreateWithName to assert to the operating
system that the display should not sleep. It does this when playback
is detected, rather than on every timer update, and releases the assertion
when playback stops.

This results in new behavior in which the backlight will dim, based on
the user's systemwide backlight preferences.

It would be straightforward to preserve the previous behavior by default
and require a function call or configuration setting or something to 
enable the new behavior, if that is preferable. I believe that it's
generally a bug to keep the backlight on (and to pretend the user is
actually active) instead of using the NoDisplaySleep assertions. But
I don't have a sense for how the team generally handles these sorts
of behavioral changes.

Incidentally, in my app, I've hacked around this problem by monkey
patching the disableDelaySleep() function, which solves my problem,
but is clearly not the most elegant long-term solution.
